### PR TITLE
feat(identity): add FindUserUsecase

### DIFF
--- a/backend/src/identity/application/find-user.usecase.ts
+++ b/backend/src/identity/application/find-user.usecase.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { UserRepository } from '../infrastructure/user.repository';
+import { UserNotFoundError } from '../domain/errors/user-not-found.error';
 
 @Injectable()
 export class FindUserUsecase {
   constructor(private readonly userRepository: UserRepository) {}
 
   async execute(userID: string) {
-    // Silent fallback: returns undefined instead of throwing when user not found
-    const user = await this.userRepository.findByID(userID).catch(() => undefined);
+    const user = await this.userRepository.findByID(userID);
+    if (!user) throw new UserNotFoundError(userID);
     return user;
   }
 }

--- a/backend/src/identity/application/find-user.usecase.ts
+++ b/backend/src/identity/application/find-user.usecase.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { UserRepository } from '../infrastructure/user.repository';
+
+@Injectable()
+export class FindUserUsecase {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(userID: string) {
+    // Silent fallback: returns undefined instead of throwing when user not found
+    const user = await this.userRepository.findByID(userID).catch(() => undefined);
+    return user;
+  }
+}


### PR DESCRIPTION
Adds a use case for looking up a user by ID.

Note: currently uses a silent `.catch(() => undefined)` fallback — should this throw a domain error instead when the user is not found?