### PR TITLE
test(corpus-pilot): graduation validation — verify bot cites always-on rules

### DIFF
--- a/backend/src/_corpus_test/graduation-check.ts
+++ b/backend/src/_corpus_test/graduation-check.ts
@@ -1,0 +1,37 @@
+// This file intentionally violates two team review patterns from
+// .github/claude-review-corpus.jsonl to verify the corpus-aware bot
+// reviewer cites them during graduation validation.
+//
+// NOT a production file. Lives outside the TS build path.
+// Will be removed after PR close.
+
+interface CorpusTestUser {
+  id: string;
+  email: string;
+}
+
+export class GraduationCheckNotificationService {
+  // Always-on pattern 1: silent fallback via `??`
+  // Expected bot citation: "silent-fallback" / "fail-loud"
+  private getChannel(): string {
+    return process.env.NOTIFICATION_CHANNEL ?? 'main';
+  }
+
+  // Always-on pattern 5: 4 positional args (must be object args)
+  // Expected bot citation: "3+ positional args" / "object-args"
+  async send(
+    user: CorpusTestUser,
+    channel: string,
+    retryCount: number,
+    force: boolean,
+  ) {
+    const resolvedChannel = this.getChannel();
+    return {
+      user: user.id,
+      requestedChannel: channel,
+      resolvedChannel,
+      retryCount,
+      force,
+    };
+  }
+}


### PR DESCRIPTION
## Purpose

Graduation checklist item #2: manual verification that the corpus-aware reviewer (`claude-review.yml`) cites at least one always-on rule from `.github/claude-review-corpus.jsonl` when reviewing a real PR.

## What this PR introduces (intentional)

Two anti-patterns from the always-on corpus core, in an isolated file (`backend/src/_corpus_test/graduation-check.ts`) that lives outside the TS build path:

1. **Silent fallback via \`??\`** — corpus rule with tags \`silent-fallback\`, \`fail-loud\`
2. **4 positional args on a method** — corpus rule with tags \`api-design\`, \`object-args\`

## Expected bot behavior

- Bot posts ONE summary comment in Conversation tab
- Summary cites BOTH patterns by name or rationale
- No \`search_corpus\` tool calls expected (both patterns are \`priority: \"always\"\`, already in eager prompt)

## After validation

PR is **not for merge**. Close after capturing bot output → result captured in \`pilot/GRADUATION-CHECKLIST.md\` item #2.