### PR TITLE
test: corpus dedup E2E validation (semantic Layer 3)

### DIFF
--- a/backend/src/_corpus_test/sample-resolver.ts
+++ b/backend/src/_corpus_test/sample-resolver.ts
@@ -1,14 +1,12 @@
 import { Resolver, Query, Args } from '@nestjs/graphql';
-import { SampleRepository } from './sample.repository';
+import { GetSampleUsecase } from './get-sample.usecase';
 
 @Resolver()
 export class SampleResolver {
-  constructor(private readonly sampleRepo: SampleRepository) {}
+  constructor(private readonly getSample: GetSampleUsecase) {}
 
-  // ANTI-PATTERN: resolver calls repository directly (violates use-case layer)
   @Query(() => String)
   async getSample(@Args('id') id: string): Promise<string> {
-    const item = await this.sampleRepo.findById(id);
-    return item?.name ?? 'not found';
+    return this.getSample.execute({ id });
   }
 }

--- a/backend/src/_corpus_test/sample-resolver.ts
+++ b/backend/src/_corpus_test/sample-resolver.ts
@@ -1,0 +1,14 @@
+import { Resolver, Query, Args } from '@nestjs/graphql';
+import { SampleRepository } from './sample.repository';
+
+@Resolver()
+export class SampleResolver {
+  constructor(private readonly sampleRepo: SampleRepository) {}
+
+  // ANTI-PATTERN: resolver calls repository directly (violates use-case layer)
+  @Query(() => String)
+  async getSample(@Args('id') id: string): Promise<string> {
+    const item = await this.sampleRepo.findById(id);
+    return item?.name ?? 'not found';
+  }
+}


### PR DESCRIPTION
## Purpose

Synthetic PR for E2E validation of Layer 3 semantic dedup (Remediation 1 R4).

After merging this PR, the extraction workflow should:
1. Extract the inline review comment as a candidate rule
2. Layer 3 should detect it as a paraphrase of existing Entry 8 and reject it
3. No new corpus commit should land

## Test plan

- [ ] Merge this PR
- [ ] Confirm `extract-review-rules.yml` fires
- [ ] Confirm action log shows `[sanitize-and-dedup] info: semantic duplicate of "..."` 
- [ ] Confirm no new `chore(corpus)` commit appears in `git log .github/claude-review-corpus.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)