### PR TITLE
test(corpus-pilot): PR-flow E2E validation (Phase 5)

### DIFF
--- a/backend/src/_corpus_test/sample-pr-flow.ts
+++ b/backend/src/_corpus_test/sample-pr-flow.ts
@@ -1,0 +1,12 @@
+import { Resolver, Query, Args } from '@nestjs/graphql';
+import { GetScheduleByDateUsecase } from './get-schedule-by-date.usecase';
+
+@Resolver()
+export class ScheduleByDateResolver {
+  constructor(private readonly getScheduleByDate: GetScheduleByDateUsecase) {}
+
+  @Query(() => String)
+  async getScheduleByDate(@Args('date') date: string): Promise<string> {
+    return this.getScheduleByDate.execute({ date });
+  }
+}


### PR DESCRIPTION
## Summary

Synthetic resolver for Phase 5 E2E validation. Adds `ScheduleByDateResolver` that accepts a raw `string` date arg with no Zod validation at the boundary.

This is the source PR for validating that:
- `extract-review-rules.yml` opens a corpus-update PR (not a direct push)
- `claude-review.yml` does NOT fire on the bot-opened corpus-PR
- `extract-review-rules.yml` does NOT re-fire when the corpus-PR is merged

## Changes

- `backend/src/_corpus_test/sample-pr-flow.ts`: synthetic resolver (non-build path)

🤖 Phase 5 E2E validation — corpus-pilot